### PR TITLE
Check if _timerIds is null on beforeDestroy

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -89,10 +89,12 @@ export default {
     },
 
     beforeDestroy() {
-        this.$data._timerIds.forEach(id => {
-            this.clearTimeout(id);
-        });
+        if (this.$data._timerIds !== null) {
+            this.$data._timerIds.forEach(id => {
+                this.clearTimeout(id);
+            });
 
-        this.$data._timerIds = null;
+            this.$data._timerIds = null;
+        }
     },
 };


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fbadge%2Fpatch-1)](https://netsells.atlassian.net/browse/patch-1)

Fix for `TypeError: "this.$data._timerIds is null"`